### PR TITLE
add search in images folder

### DIFF
--- a/.build_scripts/clean.py
+++ b/.build_scripts/clean.py
@@ -31,11 +31,18 @@ def main():
                 if ext != '.md':
                     copyfile(os.path.join('content', item), os.path.join('pdf-build',item))
         # move image files
-        for path, _, files in os.walk('content/pages'):
-            for filename in files:
-                ext = os.path.splitext(filename)[1]
-                if ext != '.md':
-                    copyfile(os.path.join(path, filename), os.path.join('pdf-build',filename))
+        if 'images' in os.listdir('content'):
+            for path, _, files in os.walk('content/images'):
+                for filename in files:
+                    ext = os.path.splitext(filename)[1]
+                    if ext != '.md':
+                        copyfile(os.path.join(path, filename), os.path.join('pdf-build',filename))
+        else:
+            for path, _, files in os.walk('content/pages'):
+                for filename in files:
+                    ext = os.path.splitext(filename)[1]
+                    if ext != '.md':
+                        copyfile(os.path.join(path, filename), os.path.join('pdf-build',filename))
         images = [f for f in os.listdir('pdf-build') if re.search(r'.*\.(jpe?g|png|gif)$', f)]
         for path, _, files in os.walk('content/pages'):
             for filename in files:


### PR DESCRIPTION
@russbiggs This isn't the best/most optimized way to do this but was a hack to get this working for the GPSDD and UAV guidelines. Putting images into a top level `images` folder was much easier to create the correct paths for getting the images to work online and in the PDF. 

It seemed to break if you put the images into a subfolder within the `images` folder so there are some improvements here. 

Other recommendations to improve or change this before we merge into the main template? 